### PR TITLE
Only build quicktype-core

### DIFF
--- a/script/publish.sh
+++ b/script/publish.sh
@@ -10,5 +10,5 @@ npm run build
 # npm publish --ignore-scripts # Don't rebuild
 
 ( cd build/quicktype-core ; node build.js publish )
-( cd build/quicktype-typescript-input ; node build.js publish )
-( cd build/quicktype-graphql-input ; node build.js publish )
+# ( cd build/quicktype-typescript-input ; node build.js publish )
+# ( cd build/quicktype-graphql-input ; node build.js publish )


### PR DESCRIPTION
We don't need to build/publish the input packages